### PR TITLE
Configure all SII schemas for JAXB Maven plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -86,6 +86,21 @@
                                     <version>${jaxb.version}</version>
                                 </plugin>
                             </plugins>
+                            <extension>true</extension>
+                            <args>
+                                <arg>-XtoString</arg>
+                                <arg>-Xequals</arg>
+                                <arg>-XhashCode</arg>
+                                <arg>-Xcopyable</arg>
+                            </args>
+                            <markGenerated>true</markGenerated>
+                            <schemaIncludes>
+                                <include>schemas.xsd</include>
+                            </schemaIncludes>
+                            <bindingIncludes>
+                                <include>bindings/bindings.xjb</include>
+                            </bindingIncludes>
+                            <locale>es</locale>
                         </configuration>
                     </execution>
                 </executions>

--- a/src/main/resources/bindings/bindings.xjb
+++ b/src/main/resources/bindings/bindings.xjb
@@ -1,0 +1,7 @@
+<bindings xmlns="https://jakarta.ee/xml/ns/jaxb" version="3.0" xmlns:xs="http://www.w3.org/2001/XMLSchema">
+    <bindings scd="x-schema::">
+        <schemaBindings>
+            <package name="cl.sii"/>
+        </schemaBindings>
+    </bindings>
+</bindings>

--- a/src/main/resources/schemas.xsd
+++ b/src/main/resources/schemas.xsd
@@ -1,0 +1,36 @@
+<xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema">
+    <!-- Documentos Tributarios Electrónicos -->
+    <xs:import namespace="http://www.sii.cl/SiiDte" schemaLocation="schemas/DTE_v10.xsd"/>
+    <xs:import namespace="http://www.sii.cl/SiiDte" schemaLocation="schemas/EnvioDTE_v10.xsd"/>
+    <xs:import namespace="http://www.sii.cl/SiiDte" schemaLocation="schemas/SiiTypes_v10.xsd"/>
+    <xs:import namespace="http://www.w3.org/2000/09/xmldsig#" schemaLocation="schemas/xmldsignature_v10.xsd"/>
+
+    <!-- Información Electrónica de Compras y Ventas -->
+    <xs:import namespace="http://www.sii.cl/SiiLce" schemaLocation="schemas/LceCal_v10.xsd"/>
+    <xs:import namespace="http://www.sii.cl/SiiLce" schemaLocation="schemas/LceCoCertif_v10.xsd"/>
+    <xs:import namespace="http://www.sii.cl/SiiLce" schemaLocation="schemas/LceSiiTypes_v10.xsd"/>
+    <xs:import namespace="http://www.sii.cl/SiiDte" schemaLocation="schemas/LibroCV_v10.xsd"/>
+
+    <!-- Libro de Guías de Despacho Electrónicas -->
+    <xs:import namespace="http://www.sii.cl/SiiDte" schemaLocation="schemas/LibroGuia_v10.xsd"/>
+
+    <!-- Intercambio entre Contribuyentes -->
+    <xs:import namespace="http://www.sii.cl/SiiDte" schemaLocation="schemas/RespuestaEnvioDTE_v10.xsd"/>
+
+    <!-- Recibo de las Mercaderías o Servicios prestados, según Ley 19.983 -->
+    <xs:import namespace="http://www.sii.cl/SiiDte" schemaLocation="schemas/EnvioRecibos_v10.xsd"/>
+    <xs:import namespace="http://www.sii.cl/SiiDte" schemaLocation="schemas/Recibos_v10.xsd"/>
+
+    <!-- Respuesta SII a Envíos Automáticos -->
+    <xs:import namespace="" schemaLocation="schemas/RespSII_v10.xsd"/>
+    <xs:import namespace="" schemaLocation="schemas/RespSIILibros_v10.xsd"/>
+
+    <!-- Boletas Electrónicas -->
+    <xs:import namespace="http://www.sii.cl/SiiDte" schemaLocation="schemas/EnvioBOLETA_v11.xsd"/>
+
+    <!-- Libro de Boletas Electrónicas -->
+    <xs:import namespace="http://www.sii.cl/SiiDte" schemaLocation="schemas/LibroBOLETA_v10.xsd"/>
+
+    <!-- Archivo de Consumo de Folios -->
+    <xs:import namespace="http://www.sii.cl/SiiDte" schemaLocation="schemas/ConsumoFolio_v10.xsd"/>
+</xs:schema>

--- a/src/main/resources/schemas/EnvioBOLETA_v11.xsd
+++ b/src/main/resources/schemas/EnvioBOLETA_v11.xsd
@@ -1258,7 +1258,7 @@
 		</xs:sequence>
 		<xs:attribute name="version" type="xs:decimal" use="required" fixed="1.0"/>
 	</xs:complexType>
-	<xs:simpleType name="RUTType">
+	<!--<xs:simpleType name="RUTType">
 		<xs:annotation>
 			<xs:documentation>Rol Unico Tributario (99..99-X)</xs:documentation>
 		</xs:annotation>
@@ -1267,8 +1267,8 @@
 			<xs:minLength value="3"/>
 			<xs:pattern value="[0-9]+-([0-9]|K)"/>
 		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="DTEType">
+	</xs:simpleType>-->
+	<!--<xs:simpleType name="DTEType">
 		<xs:annotation>
 			<xs:documentation>Tipos de Documentos Tributarios Electronicos</xs:documentation>
 		</xs:annotation>
@@ -1284,39 +1284,39 @@
 				</xs:annotation>
 			</xs:enumeration>
 		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="MntImpType">
+	</xs:simpleType>-->
+	<!--<xs:simpleType name="MntImpType">
 		<xs:annotation>
 			<xs:documentation>Monto de Impuesto - 18 digitos</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:positiveInteger">
 			<xs:totalDigits value="18"/>
 		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="MontoType">
+	</xs:simpleType>-->
+	<!--<xs:simpleType name="MontoType">
 		<xs:annotation>
 			<xs:documentation>Monto de 18 digitos - Incluye el cero</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:nonNegativeInteger">
 			<xs:totalDigits value="18"/>
 		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="ValorType">
+	</xs:simpleType>-->
+	<!--<xs:simpleType name="ValorType">
 		<xs:annotation>
 			<xs:documentation>Monto de 18 digitos - Positivo o Negativo</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:integer">
 			<xs:totalDigits value="18"/>
 		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="FolioType">
+	</xs:simpleType>-->
+	<!--<xs:simpleType name="FolioType">
 		<xs:annotation>
 			<xs:documentation>Folio de DTE - 10 digitos</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:positiveInteger">
 			<xs:totalDigits value="10"/>
 		</xs:restriction>
-	</xs:simpleType>
+	</xs:simpleType>-->
 	<xs:simpleType name="Dec1Type">
 		<xs:annotation>
 			<xs:documentation>Monto con 16 Digitos de Cuerpo y 2 Decimales </xs:documentation>
@@ -1339,7 +1339,7 @@
 			<xs:maxInclusive value="999999999999.999999"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="PctType">
+	<!--<xs:simpleType name="PctType">
 		<xs:annotation>
 			<xs:documentation>Monto de Porcentaje ( 3 y 2)</xs:documentation>
 		</xs:annotation>
@@ -1349,5 +1349,5 @@
 			<xs:minInclusive value="0.00"/>
 			<xs:maxInclusive value="100.00"/>
 		</xs:restriction>
-	</xs:simpleType>
+	</xs:simpleType>-->
 </xs:schema>

--- a/src/main/resources/schemas/LibroBOLETA_v10.xsd
+++ b/src/main/resources/schemas/LibroBOLETA_v10.xsd
@@ -711,7 +711,7 @@
 			</xs:element>
 		</xs:sequence>
 	</xs:complexType>
-	<xs:simpleType name="RUTType">
+	<!--<xs:simpleType name="RUTType">
 		<xs:annotation>
 			<xs:documentation>RUT 99999999-X</xs:documentation>
 		</xs:annotation>
@@ -720,23 +720,23 @@
 			<xs:minLength value="3"/>
 			<xs:pattern value="[0-9]+-([0-9]|K)"/>
 		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="MontoType">
+	</xs:simpleType>-->
+	<!--<xs:simpleType name="MontoType">
 		<xs:annotation>
 			<xs:documentation>Monto 18 digitos (mayor o igual a cero)</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:nonNegativeInteger">
 			<xs:totalDigits value="18"/>
 		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="ValorType">
+	</xs:simpleType>-->
+	<!--<xs:simpleType name="ValorType">
 		<xs:annotation>
 			<xs:documentation>Monto 18 digitos (positivo o negativo)</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:integer">
 			<xs:totalDigits value="18"/>
 		</xs:restriction>
-	</xs:simpleType>
+	</xs:simpleType>-->
 	<xs:simpleType name="DoctoType">
 		<xs:annotation>
 			<xs:documentation>Tipos de Documentos</xs:documentation>
@@ -754,7 +754,7 @@
 			</xs:enumeration>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="PctType">
+	<!--<xs:simpleType name="PctType">
 		<xs:annotation>
 			<xs:documentation>Porcentaje (3 enteros y 2 decimales)</xs:documentation>
 		</xs:annotation>
@@ -762,5 +762,5 @@
 			<xs:totalDigits value="5"/>
 			<xs:fractionDigits value="2"/>
 		</xs:restriction>
-	</xs:simpleType>
+	</xs:simpleType>-->
 </xs:schema>

--- a/src/main/resources/schemas/LibroCV_v10.xsd
+++ b/src/main/resources/schemas/LibroCV_v10.xsd
@@ -1363,7 +1363,7 @@
 			<xs:attribute name="version" type="xs:decimal" use="required" fixed="1.0"/>
 		</xs:complexType>
 	</xs:element>
-	<xs:simpleType name="RUTType">
+	<!--<xs:simpleType name="RUTType">
 		<xs:annotation>
 			<xs:documentation>RUT 99999999-X</xs:documentation>
 		</xs:annotation>
@@ -1372,31 +1372,31 @@
 			<xs:minLength value="3"/>
 			<xs:pattern value="[0-9]+-([0-9]|K)"/>
 		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="MontoType">
+	</xs:simpleType>-->
+	<!--<xs:simpleType name="MontoType">
 		<xs:annotation>
 			<xs:documentation>Monto 18 digitos (mayor o igual a cero)</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:nonNegativeInteger">
 			<xs:totalDigits value="18"/>
 		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="ValorType">
+	</xs:simpleType>-->
+	<!--<xs:simpleType name="ValorType">
 		<xs:annotation>
 			<xs:documentation>Monto 18 digitos (positivo o negativo)</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:integer">
 			<xs:totalDigits value="18"/>
 		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="MntImpType">
+	</xs:simpleType>-->
+	<!--<xs:simpleType name="MntImpType">
 		<xs:annotation>
 			<xs:documentation>Monto 18 digitos (> cero)</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:positiveInteger">
 			<xs:totalDigits value="18"/>
 		</xs:restriction>
-	</xs:simpleType>
+	</xs:simpleType>-->
 	<xs:simpleType name="ImptoType">
 		<xs:annotation>
 			<xs:documentation>Impuestos Adicionales</xs:documentation>
@@ -1560,7 +1560,7 @@
 			<xs:enumeration value="481"/>
 		</xs:restriction>
 	</xs:simpleType>
-	<xs:simpleType name="DoctoType">
+	<!--<xs:simpleType name="DoctoType">
 		<xs:annotation>
 			<xs:documentation>Tipos de Documentos</xs:documentation>
 		</xs:annotation>
@@ -1619,8 +1619,8 @@
 			<xs:enumeration value="500"/>
 			<xs:enumeration value="501"/>
 		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="PctType">
+	</xs:simpleType>-->
+	<!--<xs:simpleType name="PctType">
 		<xs:annotation>
 			<xs:documentation>Porcentaje (3 enteros y 2 decimales)</xs:documentation>
 		</xs:annotation>
@@ -1630,5 +1630,5 @@
 			<xs:minInclusive value="0"/>
 			<xs:maxInclusive value="100"/>
 		</xs:restriction>
-	</xs:simpleType>
+	</xs:simpleType>-->
 </xs:schema>

--- a/src/main/resources/schemas/LibroGuia_v10.xsd
+++ b/src/main/resources/schemas/LibroGuia_v10.xsd
@@ -531,7 +531,7 @@
 			<xs:attribute name="version" type="xs:decimal" use="required" fixed="1.0"/>
 		</xs:complexType>
 	</xs:element>
-	<xs:simpleType name="RUTType">
+	<!--<xs:simpleType name="RUTType">
 		<xs:annotation>
 			<xs:documentation>RUT 99999999-X</xs:documentation>
 		</xs:annotation>
@@ -539,24 +539,24 @@
 			<xs:maxLength value="10"/>
 			<xs:pattern value="[0-9]+-([0-9]|K)"/>
 		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="MontoType">
+	</xs:simpleType>-->
+	<!--<xs:simpleType name="MontoType">
 		<xs:annotation>
 			<xs:documentation>Monto 18  digitos (positivo)</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:nonNegativeInteger">
 			<xs:totalDigits value="18"/>
 		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="ValorType">
+	</xs:simpleType>-->
+	<!--<xs:simpleType name="ValorType">
 		<xs:annotation>
 			<xs:documentation>Monto 18 digitos (positivo o negativo)</xs:documentation>
 		</xs:annotation>
 		<xs:restriction base="xs:integer">
 			<xs:totalDigits value="18"/>
 		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="DoctoType">
+	</xs:simpleType>-->
+	<!--<xs:simpleType name="DoctoType">
 		<xs:annotation>
 			<xs:documentation>Tipos de Documentos</xs:documentation>
 		</xs:annotation>
@@ -598,8 +598,8 @@
 			<xs:enumeration value="918"/>
 			<xs:enumeration value="919"/>
 		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="PctType">
+	</xs:simpleType>-->
+	<!--<xs:simpleType name="PctType">
 		<xs:annotation>
 			<xs:documentation>Porcentaje (3 enteros y 2 decimales)</xs:documentation>
 		</xs:annotation>
@@ -609,5 +609,5 @@
 			<xs:minInclusive value="0"/>
 			<xs:maxInclusive value="100"/>
 		</xs:restriction>
-	</xs:simpleType>
+	</xs:simpleType>-->
 </xs:schema>

--- a/src/main/resources/schemas/README.md
+++ b/src/main/resources/schemas/README.md
@@ -2,6 +2,8 @@
 
 Los archivos XSD con los schemas de este directorio fueron obtenidos y publicados en el proyecto https://github.com/zetta-biz/sii-xsd-schemas.
 
+Solo se han comentado los types repetidos en algunos archivos XSD para permitir la construcción del artefacto. Son tipos con definiciones iguales a las ya existente en otros archivos XSD, por lo que no tienen impacto. Se han mantenido comentadas para permitir la comparación con actualizaciones de los archivos de la fuente original.
+
 Se mantienen los archivos XSD en repositorios separado con la finalidad de disponerlos en una fuente centralizada, para asegurar que permanezcan en un lugar común y estén disponibles para otros proyectos que puedan necesitarlos.
 
 ## Contribuciones

--- a/src/main/resources/schemas/RespSIILibros_v10.xsd
+++ b/src/main/resources/schemas/RespSIILibros_v10.xsd
@@ -38,7 +38,7 @@
 			</xs:sequence>
 		</xs:complexType>
 	</xs:element>
-	<xs:simpleType name="RUTType">
+	<!--<xs:simpleType name="RUTType">
 		<xs:annotation>
 			<xs:documentation>Rol Unico Tributario (99..99-X)</xs:documentation>
 		</xs:annotation>
@@ -47,10 +47,10 @@
 			<xs:minLength value="3"/>
 			<xs:pattern value="[0-9]+-([0-9]|K)"/>
 		</xs:restriction>
-	</xs:simpleType>
-	<xs:simpleType name="EnteroType">
+	</xs:simpleType>-->
+	<!--<xs:simpleType name="EnteroType">
 		<xs:restriction base="xs:nonNegativeInteger">
 			<xs:totalDigits value="10"/>
 		</xs:restriction>
-	</xs:simpleType>
+	</xs:simpleType>-->
 </xs:schema>


### PR DESCRIPTION
* Update configuration in `pom.xml`
* Import XSD files from `schemas.xsd`
* Comment already existant simpleType elements in XSD files
  * `EnvioBOLETA_v11.xsd`
  * `LibroBOLETA_v10.xsd`
  * `LibroCV_v10.xsd`
  * `LibroGuia_v10.xsd`
  * `RespSIILibros_v10.xsd`
* Enable AXB Plugins
    * `-XtoString`
    * `-Xequals`
    * `-XhashCode`
    * `-Xcopyable`
